### PR TITLE
Prevent a NaN from occurring due to imprecision

### DIFF
--- a/src/diff/solver.rs
+++ b/src/diff/solver.rs
@@ -138,7 +138,7 @@ impl FlatBlockFinder {
 
                 let trace = gxx + gyy;
                 let det = gxx * gyy - gxy.powi(2);
-                let e_sub = (trace.powi(2) - 4f64 * det).sqrt();
+                let e_sub = (trace.powi(2) - 4f64 * det).max(0.).sqrt();
                 let e1 = (trace + e_sub) / 2.0f64;
                 let e2 = (trace - e_sub) / 2.0f64;
                 // Spectral norm


### PR DESCRIPTION
With specific content, `trace=0.0000005126233499935896` and `det=0.00000000000006569567473966259` was encountered
such that `trace.powi(2) - 4f64 * det == -.00000000000000000000005865036`, which had a square root of `NaN`. This ultimately lead to a `NaN` in the score for the block, which failed an assertion on sorting the blocks by scores. Clamping the intermediate value to non-negative before taking the square root elides this edge case.