### PR TITLE
Fix compilation errors with some feature combinations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,8 @@ pub use diff::*;
 pub use estimate::*;
 #[cfg(feature = "parse")]
 pub use parse::*;
+
+#[cfg(any(feature = "diff", feature = "estimate"))]
 pub use v_frame;
 
 /// The max number of luma scaling points for grain synthesis

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "diff")]
 use std::{borrow::Cow, mem::size_of};
 
+#[cfg(feature = "diff")]
 use v_frame::{
     frame::Frame,
     prelude::{CastFromPrimitive, ChromaSampling, Pixel},


### PR DESCRIPTION
`v_frame` is only included when `diff` and/or `estimate` is enabled:

https://github.com/rust-av/av1-grain/blob/f0292b0c87b85061c702b5ef0210f2f7638e1137/Cargo.toml#L26-L33

`src/util.rs` is only used with `diff` enabled at the moment.

I checked with `cargo hack --feature-powerset check` that this compiles