### PR TITLE
Simplify NoiseStatus

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -2,7 +2,7 @@ use anyhow::{ensure, Result};
 use num_rational::Rational64;
 use v_frame::{frame::Frame, pixel::Pixel};
 
-use self::solver::{FlatBlockFinder, NoiseModel};
+use self::solver::{FlatBlockFinder, NoiseModel, NoiseModelStatus};
 use crate::{util::frame_into_u8, GrainTableSegment};
 
 mod solver;
@@ -75,7 +75,7 @@ impl DiffGenerator {
         log::debug!("Updating noise model");
         let status = self.noise_model.update(source, denoised, &flat_blocks);
 
-        if status == NoiseStatus::DifferentType {
+        if status == NoiseModelStatus::DifferentType {
             let cur_timestamp = self.frame_count as u64 * 10_000_000u64 * *self.fps.denom() as u64
                 / *self.fps.numer() as u64;
             log::debug!(
@@ -94,22 +94,6 @@ impl DiffGenerator {
         self.frame_count += 1;
 
         Ok(())
-    }
-}
-
-#[derive(Debug)]
-enum NoiseStatus {
-    Ok,
-    DifferentType,
-    Error(anyhow::Error),
-}
-
-impl PartialEq for NoiseStatus {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (&Self::Error(_), &Self::Error(_)) => true,
-            _ => core::mem::discriminant(self) == core::mem::discriminant(other),
-        }
     }
 }
 

--- a/src/diff/solver.rs
+++ b/src/diff/solver.rs
@@ -380,7 +380,7 @@ impl NoiseModel {
             NoiseModelState::new(n + 1),
             NoiseModelState::new(n + 1),
         ];
-        let mut coords = Vec::new();
+        let mut coords = Vec::with_capacity(n);
 
         let neg_lag = -(NOISE_MODEL_LAG as isize);
         for y in neg_lag..=0 {


### PR DESCRIPTION
The error inside `NoiseStatus::Error` is never read anywhere (clippy complains about this too). We could

1. Propagate the error outwards (from `DiffGenerator::diff_frame_internal`) or
2. Remove the inner error information (this PR)

Seems like the simpler solution to me.